### PR TITLE
Update database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 # x4i3 specific
 .vscode
-x4i3/data/*.pickle
-x4i3/data/*.tbl
-x4i3/data/db
-data/x4doi.txt
-x4i3/data/X4*
+x4i3/data/x4i3_X4*
 x4i3/data/EXFOR*
 x4i3/test
 *.csv
@@ -53,3 +49,4 @@ env.bak/
 venv.bak/
 
 
+x4i3/data/x4i3-2023-12-31/coupled-entries.pickle

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## x4i3 - 1.2.5 02/03/2024
+
+- Update to database version 2023/10/27.
+
 ## x4i3 - 1.2.4 05/11/2023
 
 - Fixed bug when X43I_DATAPATH is used to set the database location. In 1.2.3 the database entries would be overwritten by the default version.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## x4i3 - 1.2.5 02/03/2024
+## x4i3 - 1.2.5 05/08/2024
 
-- Update to database version 2023/10/27.
+- Update to database version 2023/12/31.
 
 ## x4i3 - 1.2.4 05/11/2023
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="x4i3",
-    version="1.2.4",
+    version="1.2.5",
     author="David A. Brown (x4i3: Anatoli Fedynitch)",
     author_email="dbrown@bnl.gov",
     maintainer="Anatoli Fedynitch",

--- a/x4i3/__init__.py
+++ b/x4i3/__init__.py
@@ -52,7 +52,7 @@ import pathlib
 
 MAJOR_VERSION = 1
 MINOR_VERSION = 2
-PATCH = 4
+PATCH = 5
 
 __package_name__ = "x4i3 -- The Exfor Interface"
 __version__ = ".".join(map(str, [MAJOR_VERSION, MINOR_VERSION, PATCH]))

--- a/x4i3/__init__.py
+++ b/x4i3/__init__.py
@@ -83,8 +83,9 @@ reactionCountFileName = "reaction-count.pickle"
 dbPath = "db"
 
 # URL to the compressed database files on github
-url = "https://github.com/avoyles/x4i3/releases/download/v1.2.5/x4i3_X4-2023-10-27.tar.gz"
+url = "https://github.com/afedynitch/x4i3/releases/download/last_before_pep8_formatting/x4i3_X4-2023-12-31.tar.gz"
 # url='https://github.com/afedynitch/x4i3/releases/download/last_before_pep8_formatting/x4i3_EXFOR-2016-04-01.tar.gz'
+current_tag = pathlib.Path(pathlib.Path(url).stem).stem
 
 if "X43I_DATAPATH" in os.environ:
     DATAPATH = pathlib.Path(os.environ["X43I_DATAPATH"])
@@ -103,8 +104,8 @@ if "X43I_DATAPATH" in os.environ:
         dbTagFile = DATAPATH / tags[0]
 else:
     # Follow default path
-    DATAPATH = pathlib.Path(__path__[0], "data").absolute()
-    dbTagFile = DATAPATH / pathlib.Path(url).stem[:-4]
+    DATAPATH = pathlib.Path(__path__[0], "data").absolute() / current_tag
+    dbTagFile = DATAPATH / current_tag
 
 
 fullIndexFileName = DATAPATH / indexFileName
@@ -114,7 +115,7 @@ fullMonitoredFileName = DATAPATH / monitoredFileName
 fullReactionCountFileName = DATAPATH / reactionCountFileName
 fullDBPath = DATAPATH / dbPath
 
-print(f"Using database version {dbTagFile.stem} located in: {DATAPATH}")
+print(f"Using database version {current_tag} located in: {DATAPATH}")
 
 # Paths for unit testing only
 # Mock db for testing
@@ -136,21 +137,21 @@ def _download_and_unpack_file(url):
     import shutil
 
     # cleanup
-    for f in [
-        fullIndexFileName,
-        fullErrorFileName,
-        fullCoupledFileName,
-        fullMonitoredFileName,
-        fullReactionCountFileName,
-        fullDBPath,
-        dbTagFile,
-    ]:
-        try:
-            shutil.rmtree(f)
-        except NotADirectoryError:
-            os.remove(f)
-        except FileNotFoundError:
-            pass
+    # for f in [
+    #     fullIndexFileName,
+    #     fullErrorFileName,
+    #     fullCoupledFileName,
+    #     fullMonitoredFileName,
+    #     fullReactionCountFileName,
+    #     fullDBPath,
+    #     dbTagFile,
+    # ]:
+    #     try:
+    #         shutil.rmtree(f)
+    #     except NotADirectoryError:
+    #         os.remove(f)
+    #     except FileNotFoundError:
+    #         pass
     # Tag files:
     
     for tagfile in DATAPATH.glob("X4-*"):
@@ -196,7 +197,8 @@ def _download_and_unpack_file(url):
 
 def check_if_exists(path, return_bool=False):
     if return_bool:
-        if not os.path.exists(path):
+        if not pathlib.Path(path).exists():
+            print("File/Directory", path, "not found. Check installation.")
             return False
         else:
             return True

--- a/x4i3/__init__.py
+++ b/x4i3/__init__.py
@@ -83,7 +83,7 @@ reactionCountFileName = "reaction-count.pickle"
 dbPath = "db"
 
 # URL to the compressed database files on github
-url = "https://github.com/afedynitch/x4i3/releases/download/last_before_pep8_formatting/x4i3_X4-2023-04-29.tar.gz"
+url = "https://github.com/avoyles/x4i3/releases/download/v1.2.5/x4i3_X4-2023-10-27.tar.gz"
 # url='https://github.com/afedynitch/x4i3/releases/download/last_before_pep8_formatting/x4i3_EXFOR-2016-04-01.tar.gz'
 
 if "X43I_DATAPATH" in os.environ:


### PR DESCRIPTION
@afedynitch,

Small proposed update here, updating the EXFOR database to v 2023-10-27, as that appears to be the most recent version in the preprocessed format that x4i3-tools uses.  NRDC has the year-end 2023 version available at https://www-nds.iaea.org/nrdc/exfor-master/exfor-2023/, but that's just the master text file, and I don't have the parser to process that into the nested x4 format used by x4i3. 

Also, as a note, I had to create a release in my fork to be able to upload the .tar.gz containing the database updates, like you do for the master branch here, so the download URL in __init__.py will point to my release - feel free to amend that once a release in the official branch is live.  If you have suggestions for a better way to handle the download URL, I;m all ears.   Thanks for the great work on this project!